### PR TITLE
Document parameters in README.md #32

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -58,26 +58,72 @@ themesDir = "../.."
     parent = "Examples"
     
 [[menu.main]]
-    name = "News"
+    name = "News sample"
     url = "/news/"
     weight = 2
     parent = "Examples"
     
 [[menu.main]]
-    name = "Membership"
+    name = "Membership sample"
     url = "/membership/"
     weight = 3
     parent = "Examples"
     
 [[menu.main]]
-    name = "Events"
+    name = "Events sample"
     url = "/events/"
     weight = 3
     parent = "Examples"
 
 [[menu.main]]
-    name = "FAQ"
+    name = "FAQ sample"
     url = "/faq/"
     weight = 4
     parent = "Examples"
 
+[[menu.main]]
+    name = "Components"
+    url = "/components/"
+    weight = 3
+ 
+[[menu.main]]
+    name = "News"
+    url = "/components/news/"
+    weight = 2
+    parent = "Components"
+    
+[[menu.main]]
+    name = "Membership"
+    url = "/components/members/"
+    weight = 3
+    parent = "Components"
+    
+[[menu.main]]
+    name = "Taxonomy list"
+    url = "/components/taxonomy_list/"
+    weight = 3
+    parent = "Components"
+    
+[[menu.main]]
+    name = "Testimonials"
+    url = "/components/testimonials/"
+    weight = 3
+    parent = "Components"
+    
+[[menu.main]]
+    name = "YouTube videos"
+    url = "/components/youtube/"
+    weight = 3
+    parent = "Components"
+    
+[[menu.main]]
+    name = "Events"
+    url = "/components/events/"
+    weight = 3
+    parent = "Components"
+
+[[menu.main]]
+    name = "FAQ"
+    url = "/components/faq/"
+    weight = 4
+    parent = "Components"

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -9,8 +9,12 @@ description: "This is an example of the Eclipse Foundation Solstice theme for Hu
 #links: [[href: "about/", text: "About"], [href: "news/", text: "News"]]
 date: 2018-04-05T15:50:25-04:00
 hide_page_title: true
-hide_sidebar: true
+hide_sidebar: false
 hide_breadcrumb: false
 ---
 
-# hugo-solstice-theme
+# Hugo Solstice theme
+
+This site contains information about the Hugo Solstice theme used on Eclipse Foundation sites, a styleguide describing usage and showing some sample pages for list content. Information about each of the base components, how they are used, and some visible samples for how content appears at different breakpoints can be seen on the [component styleguide](/components/). The pages showing this functionality can also be accessed through the Components section in the header navigation.
+
+The Hugo Solstice theme project is available under the Eclipse Public License, version 2, on GitHub. Currently the project is maintained by the in-house web development team, but like other projects under the Eclipse Foundation umbrella is open to community input and development. 

--- a/exampleSite/content/components/_index.md
+++ b/exampleSite/content/components/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Component style guide"
+date: 2019-06-23T13:30:00-00:00
+description: "Component style guide"
+---

--- a/exampleSite/content/components/faq.md
+++ b/exampleSite/content/components/faq.md
@@ -1,0 +1,16 @@
+---
+title: "FAQ"
+date: 2019-04-17T15:52:13-04:00
+description: ""
+categories: []
+keywords: []
+slug: ""
+aliases: []
+toc: false
+draft: false
+---
+
+
+**Examples:**
+
+You can see an example on the [FAQ page](/faq/)

--- a/exampleSite/content/components/index.md
+++ b/exampleSite/content/components/index.md
@@ -1,3 +1,0 @@
----
-headless: true
----

--- a/exampleSite/data/doc_params.yml
+++ b/exampleSite/data/doc_params.yml
@@ -1,0 +1,104 @@
+Title: Document Parameters
+Description: |
+  Following section describes the parameters optionally set within each of the pages within the site. These will always override parameters of the same name present in the site parameters section.
+items:
+  - 
+    name: container
+    description: If set, replaces the default container class of "container" with what is set in the parameter.
+    values:
+      - Any string value
+  - 
+    name: disable_css
+    description: Disables CSS on the given page if set to "true", otherwise is ignored.
+    values:
+      - "true"
+  - 
+    name: Description
+    description: Built in Hugo document parameter. Used in the head meta description as the primary value if set.
+    values:
+      - Any string value
+  - 
+    name: header_wrapper_class
+    description: Used in the header.html layout file, being appended to the header-wrapper class to optionally change or add to the header classes used on the page.
+    values:
+      - Any string value
+  - 
+    name: headline
+    description: If set, will render a jumbotron in the header with the given text as the headline of the content. Also used in the title meta tag when seo_title is missing from the page parameters. 
+    values:
+      - Any string value
+  - 
+    name: hide_breadcrumb
+    description:  Hides the page breadcrumb if set to true, otherwise ignored.
+    values:
+      - "true"
+  - 
+    name: hide_page_title
+    description: Hides the page title if set to true, otherwise ignored.
+    values:
+      - "true"
+  - 
+    name: hide_sidebar
+    description: Hides the main content sidebar if set to true, otherwise ignored.
+    values:
+      - "true"
+  - 
+    name: image
+    description: URL for an image that will be used on the page for TODO. Used in fallback scenarios for sharing thumbnail when share_img is not set for the page.
+    values:
+      - Absolute links or fully qualified URLs.
+  - 
+    name: keywords
+    description: Keywords to use in the head of the page, used in metadata tagging.
+    values:
+      - Array of strings
+    example: '["tag1", "tag2", "tag3"]'
+  - 
+    name: links
+    description: Optional set of links that will be included under the tagline in the jumbotron as buttons, with the text as the anchors of the buttons.
+    values:
+      - Array of URL objects that each contain values for "text" and "href" 
+    example: |
+      [[href: "about/", text: "About"], [href: "news/", text: "News"]]
+  - 
+    name: redirect_url
+    description: Set the redirect URL for client-side page forwarding. Used in the head.html layout file, and is used in the canonical URL, and in an instant refresh meta tag for page target. If set, it will also set the page to not be indexed in the future by robots.
+    values:
+      - Absolute links, relative links, or fully qualified URLs.
+  - 
+    name: seo_title
+    description: The Search Engine Optimized (SEO) title of the page. This will be used as the site title in the metadata, along with the site SEO suffix.
+    values:
+      - Any string value
+  - 
+    name: share_img
+    description: Image URL source used for thumbnails when shared via Twitter.
+    values:
+      - Absolute links or fully qualified URLs.
+  - 
+    name: show_featured_footer
+    description: Shows the featured footer section at the top of the page if set to true, otherwise is ignored.
+    values:
+      - "true"
+    ref: /components/featured_footer/
+  - 
+    name: show_featured_story
+    description: Shows the featured story section at the top of the page if set to true, otherwise is ignored.
+    values:
+      - "true"
+    ref: /components/featured_story/
+  - 
+    name: subtitle
+    description: Used in the jumbotron, set in a second level header under the headline. Ignored if headline is not set.
+    values:
+      - Any string value
+  - 
+    name: Summary
+    description: Built in Hugo document parameter. Used in the head meta description if the Description parameter is not set.
+    values:
+      - Any string value
+  - 
+    name: tagline
+    description: Optional tagline that will be inserted after the subtitle parameter in the jumbotron as the tagline under the titles for the page. 
+    values:
+      - Any string value

--- a/exampleSite/data/site_params.yml
+++ b/exampleSite/data/site_params.yml
@@ -1,0 +1,86 @@
+Title: Site Parameters
+Description: |
+  Following section describes the parameters set within the sites config.toml file, rather than parameters set at the page level. 
+items:
+  - 
+    name: call_for_action_icon
+    description: Icon class for the navbar CTA button. The icons used in Solstice are from Font Awesome, and any icon name should be prepended by 'fa-'.
+    values:
+      - Icon class from Font Awesome, prepended by 'fa-'
+    example: fa-github
+  - 
+    name: call_for_action_text
+    description: The text for the CTA button in the navbar
+    values:
+      - Any string value
+  - 
+    name: call_for_action_url
+    description: The anchor URL for the CTA button in the navbar.
+    values:
+      - Absolute link or fully qualified URL
+  - 
+    name: description
+    description: Description of the overall site, used in a pages meta description if no page level description is set.
+    values:
+      - Any string value
+  - 
+    name: favicon
+    description: URL to the favicon image for the site.
+    values:
+      - Absolute link or fully qualified URL to an image
+  - 
+    name: fb_app_id
+    description: The Facebook application ID string for the sites ad network account.
+    values:
+      - Any string value
+  - 
+    name: gcse
+    description: The Google site search collection ID string.
+    values:
+      - Any string value
+  - 
+    name: google_tag_manager
+    description: If set, the Google tag manager is activated in the footer.
+    values:
+      - "true"
+  - 
+    name: header_wrapper_class
+    description:  Used in the header.html layout file, being appended to the header-wrapper class to optionally change or add to the header classes used on the page. Only used if not set at the page level.
+    values:
+      - Any string value
+  - 
+    name: js
+    description: URL to the main javascript to be used on the site. This does not affect any scripts added in custom sctions of the site. Defaults to https://www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/main.min.js
+    values:
+      - Absolute link or fully qualified URL to a JS file
+  - 
+    name: keywords
+    description: Keywords to use in the head of the page, used in metadata tagging. Used if the keywords param is not set at the page level.
+    values:
+      - Array of strings
+    example: '["tag1", "tag2", "tag3"]'
+  - 
+    name: logo
+    description: URL to the logo image for the site. If there is no other image set in page or site parameters, this image is used as the sharing image for social media links.
+    values:
+      - Absolute link or fully qualified URL to an image
+  - 
+    name: seo_title_suffix
+    description: If set, this value is appended to the page title in the head of the page for the meta title.
+    values:
+      - Any string value
+  - 
+    name: share_img
+    description:  URL to the image used for sharing links for the site. If there is no other image set in page or site parameters, this image is used as the sharing image for social media links.
+    values:
+      - Absolute link or fully qualified URL to an image
+  - 
+    name: show_events
+    description:  Boolean value, when set to true events will be enabled on the site.
+    values:
+      - "true"
+  - 
+    name: styles
+    description: URL to the stylesheet to be used on the site. This does not affect any stylesheets added in custom sctions of the site. Defaults to https://eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/quicksilver.min.css
+    values:
+      - Absolute link or fully qualified URL to a CSS file

--- a/exampleSite/layouts/_default/index.html
+++ b/exampleSite/layouts/_default/index.html
@@ -1,38 +1,5 @@
 {{ define "main" }}
-{{ $headless := .Site.GetPage "/components" }}
-{{ $reusablePages := $headless.Resources.Match "*" }}
-<div class="col-md-18">
-  {{ .Content }} 
-  {{ range sort $reusablePages "Name" "asc" }}
-  {{ $id := .Title | lower | replaceRE "[^0-9a-z]" "-" | replaceRE "-+" "-" -}}
-  <div class="panel panel-warning" id="{{ $id }}">
-    <div class="panel-heading">{{ .Title }}</div>
-    <div class="panel-body">
-      {{ .Content }}</li>
-    </div>
-  </div>
-  {{ end }}
-</div>
-<div class="col-md-6" id="sidebar-column">
-  <nav id="main-sidebar" data-spy="affix"  data-offset-bottom="500" class="hidden-print hidden-sm hidden-xs" style="position:fixed; width: 255px;" >
-    <ul id="leftnav" class="ul-left-nav fa-ul hidden-print">
-      <li class="separator">
-        <a class="separator" href="#">Components</a>
-      </li>
-      {{ range sort $reusablePages "Name" "asc" }}
-      {{ $id := .Title | lower | replaceRE "[^0-9a-z]" "-" | replaceRE "-+" "-" -}}
-      <li><i class="fa fa-caret-right fa-fw"></i> <a href="#{{ $id }}" class="padding-reset">{{ .Title }}</a></li>
-      {{ end }}
-    </ul>
-  </nav>
-</div>
+  {{ .Content }}
+  {{ partial "param_list.html" .Site.Data.doc_params }}
+  {{ partial "param_list.html" .Site.Data.site_params }}
 {{ end }}
-
-{{ define "footer-suffix" }}
-<script> 
-$(document).ready(function() {
-  var new_width = $('#sidebar-column').width();
-  $('#main-sidebar').width(new_width); 
-});
-</script>
-{{end}}

--- a/exampleSite/layouts/components/list.html
+++ b/exampleSite/layouts/components/list.html
@@ -1,0 +1,9 @@
+{{ define "main" }}
+	<div>{{ .Content }}</div>
+	<ul>
+		{{ range sort .Pages "Title" }}
+			<li><a href="{{ .Permalink | relURL }}" title="{{ .Title }}">{{ .Title }}</a></li>
+		{{ end }}
+	</ul>
+
+{{ end }}

--- a/exampleSite/layouts/partials/param_list.html
+++ b/exampleSite/layouts/partials/param_list.html
@@ -1,0 +1,54 @@
+<!-- 
+  Copyright (c) 2019 Eclipse Foundation, Inc.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  Contributors:
+    Christopher Guindon <chris.guindon@eclipse-foundation.org>
+
+  SPDX-License-Identifier: EPL-2.0
+-->
+<div class="margin-bottom-40">
+	<h2 id="{{ .Title | urlize }}">{{ .Title }}</h2>
+	<p>{{ .Description }}</p>
+	<table class="table table-striped">
+		<thead>
+			<tr>
+				<th>Parameter name</th>
+				<th>Description</th>
+			</tr>
+		</thead>
+		<tbody>
+			{{ range sort .items "name" }}
+				<tr>
+					<td>{{ .name }}</td>
+					<td>
+						<p>{{ .description }}</p>
+						{{ if isset .values 0 }}
+							<p><em>Accepted values:</em></p>
+							<ul>
+								{{ range .values }}
+									<li>{{ . }}</li>
+								{{ end }}
+							</ul>
+						{{ end }}
+						
+						{{ if and (trim .example " " | ne "") (isset . "example") }}
+							<p>
+								<em>Example:</em> {{ .example }}
+							</p>
+						{{ end }}
+						
+						{{ if and (trim .ref " " | ne "") (isset . "ref") }}
+							<p>
+								<em>Reference:</em> <a href="{{ .ref }}">Document reference</a>
+							</p>
+						{{ end }}
+					</td>
+				</tr>
+			{{ end }}
+		</tbody>
+	</table>
+</div>

--- a/exampleSite/layouts/partials/sidebar.html
+++ b/exampleSite/layouts/partials/sidebar.html
@@ -16,12 +16,8 @@
       <a class="separator" href="{{ "index.html" | relURL }}">Hugo Solstice Theme</a>
     </li>
     <li>
-      <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ "about" | relURL }}" target="_self">About</a>
-    </li>
-    <li>
-      <i class="fa fa-caret-right fa-fw"></i>
-      <a href="{{ "news" | relURL }}" target="_self">News</a>
+      <i class="fa fa-github fa-fw fa-2x"></i>
+      <a href="https://github.com/EclipseFdn/hugo-solstice-theme" target="_self">GitHub repository</a>
     </li>
   </ul>
 </aside>


### PR DESCRIPTION
Updated site to add document + site parameters, and rearrange the
component samples into a styleguide.

Change-Id: Ib13a25251c00d94f8b97eba25d673d9973d021df
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>