### PR TITLE
Hamburger menu should be hidden on mobile if there are no nav... #66

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -49,13 +49,15 @@
           </ul>
         </div>
         <div class="navbar-header">
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-main-menu">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          </button>
+          {{ if (isset .Site.Menus "main") and (isset .Site.Menus.main 0) }}
+	          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-main-menu">
+		          <span class="sr-only">Toggle navigation</span>
+		          <span class="icon-bar"></span>
+		          <span class="icon-bar"></span>
+		          <span class="icon-bar"></span>
+		          <span class="icon-bar"></span>
+	          </button>
+          {{ end }}
           <div class="wrapper-logo-mobile">
             {{ if isset .Site.Params "logo" }}
               <a class="navbar-brand visible-xs" title="{{ .Site.Title }}" href="{{ "" | absLangURL }}">


### PR DESCRIPTION
Added check around mobile nav menu to only print if there are no
elements in the main site menu.

Change-Id: I97dd894de3e4fa041d4219d0784ef399a97f96c9
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>