### PR TITLE
Fix HTML tables #68

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -22,6 +22,7 @@ themesDir = "../.."
   call_for_action_url = "https://www.eclipse.org/downloads"
   call_for_action_icon = "fa-download"
   show_events = true
+  table_classes = "table table-bordered"
 
 [Author]
   name = "Christopher Guindon"
@@ -146,5 +147,11 @@ themesDir = "../.."
 [[menu.main]]
     name = "Project list"
     url = "/components/project_list/"
+    weight = 3
+    parent = "Components"
+    
+[[menu.main]]
+    name = "HTML Tables"
+    url = "/components/tables/"
     weight = 3
     parent = "Components"

--- a/exampleSite/content/components/tables.md
+++ b/exampleSite/content/components/tables.md
@@ -1,0 +1,46 @@
+---
+title: 'HTML Tables'
+table_classes: "table table-striped"
+---
+
+Table injection functionality has been added to the base theme for Hugo. This has been added in the partial `footer_hugo.html` for the actual JS, and a partial has been added to the head named `head_variables.html`. This file will contain variables used within the code that are set in site or page parameters.  
+
+To change injected table classes, a parameter of `table_classes` can be set at either the page or site level. If not set, the default value of `table` will be injected to affect bootstrap table look and feel on tables.
+
+## Markdown table
+
+| Tables        | Are           | Cool  |
+| ------------- |:-------------:| -----:|
+| col 3 is      | right-aligned | $1600 |
+| col 2 is      | centered      |   $12 |
+| zebra stripes | are neat      |    $1 |
+
+## Custom HTML Table
+
+<table>
+    <tr>
+        <th>Sample</th>
+        <th>Table</th>
+        <th>Custom</th>
+    </tr>
+    <tr>
+        <td>Class</td>
+        <td>was</td>
+        <td>injected</td>
+    </tr>
+</table>
+
+## Custom HTML Table w/ class
+
+<table class="custom">
+    <tr>
+        <th>Sample</th>
+        <th>Table</th>
+        <th>Custom</th>
+    </tr>
+    <tr>
+        <td>Class</td>
+        <td>wasn't</td>
+        <td>replaced</td>
+    </tr>
+</table>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -102,3 +102,10 @@
 {{- with .Site.Params.js | default "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/main.min.js"}}
 <script src="{{ . | absURL }}"></script>
 {{ end }}
+{{ if isset .Site.Params "hugo_js" }}
+  {{- with .Site.Params.hugo_js }}
+    <script src="{{ . | absURL }}"></script>
+  {{ end }}
+{{ else }}
+    <script src="{{ "/js/solstice.hugo.js" | absURL }}"></script>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -65,3 +65,4 @@
 {{- end }}
 {{- end }}
 {{- partial "google_tag_manager.html" . }}
+{{- partial "head_variables.html" . }}

--- a/layouts/partials/head_variables.html
+++ b/layouts/partials/head_variables.html
@@ -1,0 +1,21 @@
+<!-- 
+  Copyright (c) 2019 Eclipse Foundation, Inc.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  Contributors:
+    Martin Lowe <martin.lowe@eclipse-foundation.org>
+
+  SPDX-License-Identifier: EPL-2.0
+-->
+<script>
+	{{ if isset .Params "table_classes" }}
+		var tableClasses = {{ .Params.table_classes }};
+	{{ else if isset .Site.Params "table_classes" }}
+		var tableClasses = {{ .Site.Params.table_classes }};
+	{{ else }}
+		var tableClasses = "table";
+	{{ end }}
+</script>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -17,3 +17,8 @@ mix.scripts([
     './node_modules/eclipsefdn-solstice-assets/js/solstice.cookies.js',
     './node_modules/eclipsefdn-solstice-assets/js/solstice.js'
 ], './static/js/solstice.js');
+
+
+mix.scripts([
+    './node_modules/eclipsefdn-solstice-assets/js/solstice.tables.js'
+], './static/js/solstice.hugo.js');


### PR DESCRIPTION
Added table injection logic to a new JS file called hugo-custom.js,
created by an updated webpack file. The logic was added to the footer
after solstice injection (to ensure Bootstrap is loaded) in a new
footer_hugo partial. Variables for the table injection are set within
the head to be used in the page.

Change-Id: Ib99d75ded1caaf58241771bcefa176543016d68f
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>