### PR TITLE
Fix navbar for versions of hugo < v 0.55

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -50,7 +50,7 @@
             </ul>
           </div>
           <div class="navbar-header">
-            {{ if (isset .Site.Menus "main") and (isset .Site.Menus.main 0) }}
+            {{ if (ne .Site.Menus.main nil) and (ne (first .Site.Menus.main) nil) }}
 	            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-main-menu">
 		            <span class="sr-only">Toggle navigation</span>
 		            <span class="icon-bar"></span>


### PR DESCRIPTION
Switch isset usage in navbar mobile menu check to use simple
comparisons, as 'isset' is not supported for menus in versions 54 and
earlier.

Change-Id: I485cc874d88d32f13ac33b82c9d6e707b17515bb
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>