### PR TITLE
Added ability to hide CTA on page of link via site param

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -19,10 +19,11 @@ themesDir = "../.."
   gcse = ""
   header_wrapper_class = "header-default-bg-img"
   call_for_action_text = "Download"
-  call_for_action_url = "https://www.eclipse.org/downloads"
+  call_for_action_url = "/downloads"
   call_for_action_icon = "fa-download"
   show_events = true
   table_classes = "table table-bordered"
+  hide_cfa_same_page = true
 
 [Author]
   name = "Christopher Guindon"

--- a/exampleSite/content/downloads/_index.md
+++ b/exampleSite/content/downloads/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Downloads"
+seo_title: "Downloads"
+description: "This is an example of the Eclipse Foundation Solstice theme for Hugo."
+date: 2018-04-05T15:50:25-04:00
+layout: "single"
+---

--- a/exampleSite/data/site_params.yml
+++ b/exampleSite/data/site_params.yml
@@ -17,7 +17,7 @@ items:
     name: call_for_action_url
     description: The anchor URL for the CTA button in the navbar.
     values:
-      - Absolute link or fully qualified URL
+      - Absolute link or fully qualified URL. For best results with internal URLs, end URLs without extensions with a slash. e.g. /downloads -> /downloads/
   - 
     name: description
     description: Description of the overall site, used in a pages meta description if no page level description is set.
@@ -53,6 +53,11 @@ items:
     description:  Used in the header.html layout file, being appended to the header-wrapper class to optionally change or add to the header classes used on the page. Only used if not set at the page level.
     values:
       - Any string value
+  - 
+    name: hide_cfa_same_page
+    description: Attempt to hide CFA on the page it links to 
+    values:
+      - "true"
   - 
     name: js
     description: URL to the main javascript to be used on the site. This does not affect any scripts added in custom sctions of the site. Defaults to https://www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/main.min.js

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -40,7 +40,17 @@
         {{ $has_cfa = 1 }}
       {{ end }}
       <div class="{{ $.Site.Params.main_menu_wrapper_classes | default "col-sm-19 col-md-20 margin-top-10" }}{{ if eq $has_cfa 0}} reset{{ end }}" id="main-menu-wrapper">
-        {{ if eq $has_cfa 1 }}
+        {{ $normalized_cta_url := .Site.Params.call_for_action_url }}
+        {{ if (eq (len (findRE `(\.[^\/]{3,4}|\/)$` $normalized_cta_url)) 0) }}
+          {{ $normalized_cta_url = printf "%s/" $normalized_cta_url }}
+        {{ end }}
+        
+        {{ $abs_cfa := printf "%s" ($normalized_cta_url | absURL) }}
+        {{ $is_cfa_page := 0 }}
+        {{ if or (eq $normalized_cta_url .Permalink) (eq $abs_cfa .Permalink) }}
+          {{ $is_cfa_page = 1 }}
+        {{ end }}
+        {{ if and (eq $has_cfa 1) (not (or (eq .Site.Params.hide_cfa_same_page "true") (eq $is_cfa_page 1))) }}
           <div class="{{ $.Site.Params.call_for_action_wrapper_classes | default "float-right hidden-xs" }}" id="btn-call-for-action">
             <div id="btn-call-for-action"><a href="{{ .Site.Params.call_for_action_url }}" class="{{ .Site.Params.call_for_action_classes | default "btn btn-huge btn-warning" }}"><i class="fa {{ .Site.Params.call_for_action_icon }}"></i> {{ .Site.Params.call_for_action_text }}</a></div>
           </div>


### PR DESCRIPTION
Added `hide_cfa_same_page` site param to hide CFA links on page of.

Change-Id: If1376cfd2dea3b26630e1f38248482486d92ba95
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>