### PR TITLE
Update to support hugo 0.62.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - "12"
 install:
 - npm install
-- wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_0.54.0_Linux-64bit.deb
+- wget https://github.com/gohugoio/hugo/releases/download/v0.62.2/hugo_0.62.2_Linux-64bit.deb
 - sudo dpkg -i hugo*.deb
 script:
 - npm run production

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 Have a bug or a feature request? Please search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/eclipsefdn/hugo-solstice-theme/issues/new).
 
+## Known issues
+
+- Versions of Hugo 0.60 and beyond do not support raw HTML in markdown files by default. To enable this feature, unsafe HTML rendering can be enabled in the Goldmark engine in the site configuration. This is not recommended as it exposes rendered content vulnerable to injected content on the site.
+
 ## Author
 
 **Christopher Guindon (Eclipse Foundation)**

--- a/exampleSite/content/components/tables.md
+++ b/exampleSite/content/components/tables.md
@@ -7,6 +7,9 @@ Table injection functionality has been added to the base theme for Hugo. This ha
 
 To change injected table classes, a parameter of `table_classes` can be set at either the page or site level. If not set, the default value of `table` will be injected to affect bootstrap table look and feel on tables.
 
+Please note, that versions of Hugo 0.60 and beyond do not support raw HTML in markdown files by default. To enable this feature, unsafe HTML rendering can be enabled in the Goldmark engine in the site configuration. This site has not been configured to render unsafe content, meaning that the custom HTML table section will appear empty when running in versions of Hugo 0.60 and greater.
+
+
 ## Markdown table
 
 | Tables        | Are           | Cool  |
@@ -15,7 +18,7 @@ To change injected table classes, a parameter of `table_classes` can be set at e
 | col 2 is      | centered      |   $12 |
 | zebra stripes | are neat      |    $1 |
 
-## Custom HTML Table
+## Custom HTML Table  
 
 <table>
     <tr>
@@ -29,6 +32,7 @@ To change injected table classes, a parameter of `table_classes` can be set at e
         <td>injected</td>
     </tr>
 </table>
+
 
 ## Custom HTML Table w/ class
 

--- a/exampleSite/data/featuredstory.yml
+++ b/exampleSite/data/featuredstory.yml
@@ -19,7 +19,7 @@ items:
     link: <a class="btn btn-primary btn-lg" href="/documents/insights/2019-jakarta-ee-developer-survey.pdf">See the report!</a>
     bgImgSrc: https://www.eclipse.org/home/images/ece-2019-banner.jpg
     startDate: 2019-07-17
-    endDate: 2019-07-30
+    endDate: 2099-07-30
     type: both
   -
     preamble: Now available

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -215,7 +215,7 @@
   other = "Date"
 
 [members-list-members-label]
-  other = "{{ . }} Members"
+  other = "{{ .Count }} Members"
 
 [members-list-all-members]
   other = "All members"


### PR DESCRIPTION
Updated some broken i18n values in newer versions, added note about
custom HTML in content files as a known issue. Updated a featured story
to be available in perpetuity.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>