### PR TITLE
Remove title from jumbotron header. Causes breakages with safeHTML

### DIFF
--- a/layouts/partials/jumbotron.html
+++ b/layouts/partials/jumbotron.html
@@ -15,7 +15,7 @@
   <div class="container">
     <div class="row">
       <div class="{{- .Params.jumbotron_class | default .Site.Params.jumbotron_class | default "col-md-20 col-md-offset-2 col-sm-18 col-sm-offset-3"}}">
-        <h1>{{ .Page.Params.headline | title | safeHTML }}</h1>
+        <h1>{{ .Page.Params.headline | safeHTML }}</h1>
          {{ if isset .Page.Params "subtitle" }}
         <h2>{{ .Page.Params.subtitle  | title }}</h2>
          {{end}} 


### PR DESCRIPTION
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>