### PR TITLE
Fixed container-fluid banner examples to use proper class for detection

### DIFF
--- a/exampleSite/content/components/agenda.md
+++ b/exampleSite/content/components/agenda.md
@@ -1,5 +1,7 @@
 ---
 Title: Agenda
+container: "container-fluid"
+hide_sidebar: true
 ---
 
 Agendas can be added to the site through an `agenda.yaml` data file added in a subfolder of the data folder for the target locale (for localization, for default, create/use the "en" folder). An example of this path is as follows, `data/en/agenda.yaml`. The data should be similar to the following format: 
@@ -43,6 +45,34 @@ Types represent the different types of sessions being held at the event. Normall
 ```
 
 Items in these data files represent the actual sessions to be represented in the agenda.  
+
+---
+
+## Basic  
+
+Targets ./data/en/agenda.yaml:  
+
+
+{{< agenda >}}
+
+---
+
+## Section class  
+
+Targets ./data/en/agenda.yaml:  
+
+
+{{< agenda sectionClass="background-secondary alt">}}
+
+---
+
+
+## Container class  
+
+Targets ./data/en/agenda.yaml:  
+
+
+{{< agenda sectionClass="background-secondary alt" containerClass="container-fluid">}}
 
 ---
 

--- a/exampleSite/content/components/registration.md
+++ b/exampleSite/content/components/registration.md
@@ -28,9 +28,9 @@ Register for this event!
 I have links too. Not very useful though.
 {{</ registration >}}
 
-## Banner w/ background
+## Section class w/ background
 
-{{< registration banner="true" sectionClass="background-secondary">}}
+{{< registration sectionClass="background-secondary">}}
 Register for this event!
 
 I have links too. Not very useful though.
@@ -38,7 +38,7 @@ I have links too. Not very useful though.
 
 ## Year
 
-{{< registration year="2020" banner="true" sectionClass="background-secondary">}}
+{{< registration year="2020" sectionClass="background-secondary">}}
 Register for this event!
 
 I have links too. Not very useful though.
@@ -46,20 +46,20 @@ I have links too. Not very useful though.
 
 ## No content
 
-{{< registration banner="true" sectionClass="background-secondary">}}
+{{< registration sectionClass="background-secondary">}}
 {{</ registration >}}
 
 ## Event registration
 
-{{< registration event="sample" banner="true" sectionClass="background-secondary">}}
+{{< registration event="sample" sectionClass="background-secondary">}}
 {{</ registration >}}
 
 ## Event+year registration
 
-{{< registration event="sample" year="2020" banner="true" sectionClass="background-secondary">}}
+{{< registration event="sample" year="2020" sectionClass="background-secondary">}}
 {{</ registration >}}
 
 ## Expired
 
-{{< registration event="expired_event" banner="true" sectionClass="background-secondary">}}
+{{< registration event="expired_event" sectionClass="background-secondary">}}
 {{</ registration >}}

--- a/exampleSite/content/components/user_display.md
+++ b/exampleSite/content/components/user_display.md
@@ -8,6 +8,8 @@ slug: ""
 aliases: []
 toc: false
 draft: false
+container: container-fluid
+hide_sidebar: true
 ---
 
 !!TODO
@@ -36,7 +38,7 @@ Sed quis tellus ligula. Mauris aliquam risus lectus, vitae pretium ex imperdiet 
 {{< user_display event="sample" headerClass="h3" useCarousel="false" />}}
 
 ## Section class
-{{< user_display event="sample" sectionClass="text-center" useCarousel="false" />}}
+{{< user_display event="sample" sectionClass="background-secondary alt" useCarousel="false" />}}
 
 ## Title
 {{< user_display event="sample" useCarousel="false" title="Some new title" />}}

--- a/layouts/shortcodes/agenda.html
+++ b/layouts/shortcodes/agenda.html
@@ -39,88 +39,105 @@
   {{ end }}
 {{ end }}
 
+{{$cont:=(.Page.Params.container | default .Site.Params.container | default "container")}}
+{{ $sectionId := .Get "sectionId" | default "registration" }}
+{{ $sectionClass := .Get "sectionClass" }}
+{{ $containerClass := .Get "containerClass" | default "container" }}
 <style>
-{{ range $types}}
-{{if .color }} 
-.eclipsefdn-agenda span.legend-icon.legend-{{ urlize .id }}-icon::after { background-color: {{ .color }}; }
-{{end}}
+{{ range $types }}
+{{ if .color }}
+.eclipsefdn-agenda span.legend-icon.legend-{{ urlize .id }}-icon::after {
+  background-color: {{ .color }};
+}
+{{ end }}
 {{ end }}
 </style>
-<div class="eclipsefdn-agenda">
-  {{ if $types }}
-  <div class="row">
-  <h3>{{ i18n "agenda-legend" }}</h3>
-  <ul type="none">
-    {{ range $types }}
-      <li><span class="legend-{{ .id }}-icon legend-icon">&nbsp;</span> {{ .name }}</li>
-    {{ end }}
-  </ul>
+<section class="{{ if eq $cont "container-fluid" }}row {{ end }}{{ $sectionClass }}"
+  {{- with $sectionId}} id="{{.}}"{{ end -}}>
+  {{ if eq $cont "container-fluid" }}
+    <div class="{{ $containerClass }}">
+  {{ end }}
+    <div class="eclipsefdn-agenda">
+      {{ if $types }}
+      <div class="row">
+        <div class="col-xs-24">
+          <h3>{{ i18n "agenda-legend" }}</h3>
+          <ul type="none">
+            {{ range $types }}
+            <li><span class="legend-{{ .id }}-icon legend-icon">&nbsp;</span> {{ .name }}</li>
+            {{ end }}
+          </ul>
+        </div>
+      </div>
+      {{ end }}
+      <div class="row">
+        <div class="col-xs-24">
+          <h3>{{ i18n "agenda-sessions" }}</h3>
+          <table class="table">
+            <thead>
+              <tr>
+                <th>{{ i18n "agenda-session-name" }}</th>
+                <th>{{ i18n "agenda-presenter-name" }}</th>
+                {{ if $complete }}
+                <th class="text-center">{{ i18n "agenda-session-recording" }}</th>
+                {{ else }}
+                <th>{{ i18n "agenda-session-schedule" }}</th>
+                {{ end }} 
+                {{ if $has_slides }}
+                <th class="text-center">{{ i18n "agenda-session-slides" }}</th>
+                {{ end }}
+              </tr>
+            </thead>
+            <tbody>
+              {{ range $events }}
+              <tr>
+                <td>
+                {{ if $types }} 
+                <span class="legend-{{ .type }}-icon legend-icon"> 
+                  <span class="sr-only"> {{ range first 1 (where $types "id" .type) }} {{ .name }} {{ end}} </span>
+                </span> 
+                {{ end }} 
+                {{ .name }} 
+                {{ if isset . "abstract" }} 
+                <a class="margin-left-10" href="#" title="{{ i18n " agenda-abstract-modal-alt" . }}" 
+                  data-toggle="modal" data-target="#eclipsefdn-modal" data-title="{{ .name }}" data-presenter="{{ .presenter }}" data-time="{{ .time }}"> 
+                  <i class="fa fa-external-link"> 
+                    <span class="sr-only">
+                      {{ i18n "agenda-abstract-modal-alt" . }}
+                    </span>
+                    <div class="modal-content hidden">{{ .abstract | safeHTML }}</div>
+                  </i>
+                </a> 
+                {{ end }}
+                </td>
+                <td>{{ .presenter }}</td>
+                {{ if $complete }}
+                <td class="text-center">
+                  <a class="btn btn-primary btn-wide" href="{{ .vod }}" title="{{ i18n "agenda-session-recording-button-alt" . }}">
+                    <i class="fa fa-play"></i><span class="sr-only">{{ i18n "agenda-session-recording-button-alt" . }}</span>
+                  </a>
+                </td>
+                {{ else }}
+                <td>{{ .time }}</td>
+                {{ end }}
+                <!-- Write the slide column if it has been set -->
+                {{ if $has_slides }}
+                <td class="text-center">
+                  {{ if (isset . "slides") }} 
+                    <a class="btn btn-primary btn-wide" href="{{ .slides }}" title="{{ i18n "agenda-session-slides-button-alt" . }}"> 
+                      <i class="fa fa-file"></i> <span class="sr-only">{{ i18n "agenda-session-slides-button-alt" . }}</span>
+                    </a>
+                  {{ end }}
+                </td>
+                {{ end }}
+              </tr>
+              {{ end }}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  {{ if and (ne (.Get "checkContainer") "false") (eq $cont "container-fluid") }}
   </div>
   {{ end }}
-  <div class="row">
-  <h3>{{ i18n "agenda-sessions" }}</h3>
-	<table class="table">
-	  <thead>
-	    <tr>
-	      <th>{{ i18n "agenda-session-name" }}</th>
-	      <th>{{ i18n "agenda-presenter-name" }}</th>
-	      {{ if $complete }}
-	      <th class="text-center">{{ i18n "agenda-session-recording" }}</th>
-	      {{ else }}
-	      <th>{{ i18n "agenda-session-schedule" }}</th>
-	      {{ end }}
-	      {{ if $has_slides }}
-	      <th class="text-center">{{ i18n "agenda-session-slides" }}</th>
-	      {{ end }}
-	    </tr>
-	  </thead>
-	  <tbody>
-	    {{ range $events }}
-	    <tr>
-	      <td>
-            {{ if $types }}
-	        <span class="legend-{{ .type }}-icon legend-icon">
-	          <span class="sr-only">
-	          {{ range first 1 (where $types "id" .type) }} 
-	          {{ .name }} 
-	          {{ end}}
-	          </span>
-	        </span> 
-            {{ end }}
-            {{ .name }}
-            {{ if isset . "abstract" }}
-            <a class="margin-left-10" href="#" title="{{ i18n "agenda-abstract-modal-alt" . }}" data-toggle="modal" data-target="#eclipsefdn-modal" 
-            	data-title="{{ .name }}" data-presenter="{{ .presenter }}" data-time="{{ .time }}">
-	            <i class="fa fa-external-link">
-	            	<span class="sr-only">{{ i18n "agenda-abstract-modal-alt" . }}</span>
-	            	<div class="modal-content hidden">{{ .abstract | safeHTML }}</div>
-	            </i>
-            </a>
-            {{ end }}
-	      </td>
-	      <td>{{ .presenter }}</td>
-	      
-	      {{ if $complete }}
-	      <td class="text-center">
-	      <a class="btn btn-primary btn-wide" href="{{ .vod }}" title="{{ i18n "agenda-session-recording-button-alt" . }}">
-	        <i class="fa fa-play"></i> <span class="sr-only">{{ i18n "agenda-session-recording-button-alt" . }}</span>
-	      </a></td>
-	      {{ else }}
-	      <td>{{ .time }}</td>
-	      {{ end }}
-	      <!-- Write the slide column if it has been set -->
-	      {{ if $has_slides }}
-	      <td class="text-center">
-	        {{ if (isset . "slides") }}
-	        <a class="btn btn-primary btn-wide" href="{{ .slides }}" title="{{ i18n "agenda-session-slides-button-alt" . }}">
-	          <i class="fa fa-file"></i> <span class="sr-only">{{ i18n "agenda-session-slides-button-alt" . }}</span>
-	        </a>
-	        {{ end }}
-	      </td>
-	      {{ end }}
-	    </tr>
-	    {{ end }}
-	  </tbody>
-	</table>
-  </div>
-</div>
+</section>

--- a/layouts/shortcodes/registration.html
+++ b/layouts/shortcodes/registration.html
@@ -23,14 +23,16 @@
 {{ $base := .Scratch.Get "base" }}
 {{ $registration := (index $base $event_id).registration }}
 
-{{ $useBanner := .Get "banner" | default "false" }}
+{{ $cont := (.Page.Params.container | default .Site.Params.container | default "container") }}
 {{ $sectionId := .Get "sectionId" | default "registration" }}
 {{ $sectionClass := .Get "sectionClass" }}
+{{ $containerClass := .Get "containerClass" | default "container" }}
 {{ $t := time $registration.end_date }}
 
-<section id="{{ $sectionId }}"{{- with $sectionClass }} class="{{ . }}"{{ end }}>  
-  {{ if and (eq $useBanner "true") (eq $cont "container-fluid") }} 
-  <div class="container">
+<section class="{{ if eq $cont "container-fluid" }}row {{ end }}{{ $sectionClass }}"
+  {{- with $sectionId}} id="{{.}}"{{ end -}}>
+  {{ if eq $cont "container-fluid" }} 
+  <div class="{{ $containerClass }}">
   {{ end }}
   <div class="padding-bottom-40 padding-top-40">
     <div class="row">
@@ -45,7 +47,7 @@
         <div class="pre-event{{ if $t.Before now }} hidden{{ end }}">
           {{ .Inner | markdownify }}
           {{- with $registration.links }}
-          <ul class="list-inline">
+          <ul class="list-inline cta-links">
             {{ range . }}
             <li><a href="{{ .url }}" class="btn btn-primary"{{ if eq .external "true" }} target="_blank"{{ end }}>{{ .text }}</a></li>
             {{ end }}
@@ -59,7 +61,7 @@
       </div>
     </div>
   </div>
-  {{ if and (eq $useBanner "true") (eq $cont "container-fluid") }} 
+  {{ if eq $cont "container-fluid" }} 
   </div>
   {{ end }}
 </section>

--- a/layouts/shortcodes/user_display.html
+++ b/layouts/shortcodes/user_display.html
@@ -21,9 +21,12 @@
 {{ $event := .Get "event" | default "default" }}
 {{ $source := .Get "source" | default "user" }}
 
+{{ $cont := (.Page.Params.container | default .Site.Params.container | default "container") }}
 {{ $useCarousel:= .Get "useCarousel" | default "true" }}
 {{ $headerClass:= .Get "headerClass" | default "padding-bottom-20"}}
 {{ $sectionClass:= .Get "sectionClass" | default ""}}
+{{ $containerClass := .Get "containerClass" | default "container padding-bottom-40 padding-top-40" }}
+{{ $sectionId:= .Get "sectionId" }}
 {{ $title := .Get "title" | default (i18n "committee-carousel-title") }}
 {{ $subpage := .Get "subpage" }}
 {{ $subpageURL := "" }}
@@ -38,9 +41,12 @@
     {{ $subpageURL = printf "/%s" $subpage }}
   {{ end }}
 {{ end }}
-<section {{with $sectionClass}} class="{{ $sectionClass }}"{{ end }}>
+<section class="{{ if eq $cont "container-fluid" }}row {{ end }}{{ $sectionClass }}"
+  {{- with $sectionId}} id="{{.}}"{{ end -}}>
   <!-- Start: Users Area-->
-  <div class="container padding-bottom-40 padding-top-40">
+  {{ if eq $cont "container-fluid" }}
+  <div class="{{ $containerClass }}">
+  {{ end }}
     <div class="row"> 
       <div class="col-xs-24 {{ if $subpage }}col-sm-18 match-height-item-by-row{{ end }}">
         <h2 {{with $headerClass}} class="{{ $headerClass }}"{{ end }}>{{ $title }}</h2>
@@ -89,6 +95,8 @@
       </div>
     </div>
     <!-- Start: Users Body Area -->
+  {{ if eq $cont "container-fluid" }}
   </div>
+  {{ end }}
   <!-- End:  "container"-->
 </section>


### PR DESCRIPTION
Updated registration, agenda, and user_display to enable automatic
detection of container-fluid being set. Removed the 'banner' attribute.
Added a named param for container class to the registration,
user_display, and agenda components.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>