### PR TITLE
Tweaks to events generic templates to increase flexibility

### DIFF
--- a/layouts/shortcodes/events/agenda.html
+++ b/layouts/shortcodes/events/agenda.html
@@ -19,16 +19,10 @@
   {{ .Scratch.Set "base" (index .Site.Data $currLang) }}
 {{ end }}
 {{ $base := .Scratch.Get "base" }}
-{{ .Scratch.Set "agenda" $base.agenda }}
-
-<!-- Allow for addition of event sub-site if set -->
-{{$event_id := .Get "event"}}
-{{ if and ($event_id) (ne $event_id "") }}
-  {{ .Scratch.Set "agenda" (index $base $event_id).agenda }}
-{{ end }}
-{{$events := (.Scratch.Get "agenda").items}}
-{{$types := (.Scratch.Get "agenda").types}}
-{{$complete := (.Scratch.Get "agenda").complete }}
+{{ $event_id := .Get "event" | default "default" }}
+{{$events := (index $base $event_id).agenda.items}}
+{{$types := (index $base $event_id).agenda.types}}
+{{$complete := (index $base $event_id).agenda.complete }}
 <!-- Allow for adjusted titles -->
 {{$title_suffix := .Get "title" }}
 <!-- Check for slide column -->

--- a/layouts/shortcodes/events/registration.html
+++ b/layouts/shortcodes/events/registration.html
@@ -30,7 +30,7 @@
         {{ $registration.image | safeHTML }}
       </div>
     {{ end }}
-    <div class="eclipsefdn-registration-content col-xs-24 text-middle text-center {{- if $registration.image }}col-md-18 match-height-item-by-row{{ end -}}"
+    <div class="eclipsefdn-registration-content col-xs-24 text-middle text-center {{ if $registration.image }}col-md-18 match-height-item-by-row{{ end }}"
       data-end="{{ $t }}">
       <h2>{{ .Get "title" | default $registration.title }}</h2>
       <div class="eclipsefdn-registration-body">

--- a/layouts/shortcodes/events/user_display.html
+++ b/layouts/shortcodes/events/user_display.html
@@ -23,6 +23,7 @@
 
 {{ $useCarousel:= .Get "useCarousel" | default "true" }}
 {{ $title := .Get "title" | default (i18n "committee-carousel-title") }}
+{{ $imageRoot := .Get "imageRoot" | default "/images/committee/" }}
 {{ $subpage := .Get "subpage" }}
 {{ $subpageURL := "" }}
 {{ if $subpage }}
@@ -41,7 +42,7 @@
   <div class="row">
     <div class="eclipsefdn-user-display-heading col-xs-24 {{ if $subpage }}col-sm-18 match-height-item-by-row{{ end }}">
       <h2{{ with .Get "headerClass" }} class="{{ . }}"{{ end }}>{{ $title }}</h2>
-      {{- with .Inner }}{{ . | markdownify }}{{ end -}}
+      {{ with .Inner }}{{ . | markdownify }}{{ end }}
     </div>
     
     {{ with $subpageURL }}
@@ -62,7 +63,7 @@
         {{ end }}
         <div class="item padding-40 {{ if ne $useCarousel "true" }} col-xs-12 col-sm-6 match-height-item-by-row{{ end }}">
           {{ if .img }}
-          <img src="/images/committee/{{ .img }}" alt="{{ .name }}">
+          <img class="img img-responsive" src="{{ $imageRoot }}{{ .img }}" alt="{{ .name }}">
           {{ else }}
           <div class="icon-backdrop text-center">
             <div class="ratio"></div>


### PR DESCRIPTION
Changes found while migrating jakartaone that required tweaks to carry
over. Added imageroot and image classes to user carousel images, fixed
registration classees to properly render with images, and made the event
ID handling consistent in the agenda.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>