### PR TITLE
Added fixes needed for openPASS content update

### DIFF
--- a/layouts/shortcodes/bootstrap/button.html
+++ b/layouts/shortcodes/bootstrap/button.html
@@ -1,0 +1,18 @@
+<!-- 
+  Copyright (c) 2020 Eclipse Foundation, Inc.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+
+  Contributors:
+    Martin Lowe <martin.lowe@eclipse-foundation.org>
+
+  SPDX-License-Identifier: EPL-2.0
+-->
+{{ $pClass := .Get "pClass" }}
+{{ $linkClass := .Get "linkClass" | default "btn-primary" }}
+{{ $title := .Get "title" }}
+<p {{ with $pClass }}class="{{ . }}"{{ end }}>
+  <a class="btn {{ $linkClass }}" {{ with $title }}title="{{ . }}"{{ end }} href="{{ .Get "href" }}">{{- .Inner -}}</a>
+</p>

--- a/layouts/shortcodes/members_list.html
+++ b/layouts/shortcodes/members_list.html
@@ -36,7 +36,7 @@
         {{ range $index, $level := $.Site.Taxonomies.participation_levels }}
           <div class="tab-pane active" id="tab-{{$index}}">
           <h3 class="block-heading">{{ humanize $index }}</h3>
-          {{ range .Pages}}
+          {{ range sort .Pages "Title"}}
             {{ .Scratch.Set "link" .RelPermalink }}
     
             {{ if .Params.link }}


### PR DESCRIPTION
Fixed sorting on members list to be insensitive alphabetical order
rather than case sensitive. Added button shortcode to insert buttons
into page files without templates.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>