### PR TITLE
Remove libre franklin from base theme

### DIFF
--- a/layouts/partials/head_custom.html
+++ b/layouts/partials/head_custom.html
@@ -10,4 +10,4 @@
 
   SPDX-License-Identifier: EPL-2.0
 -->
-<link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet" type="text/css"/>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Roboto is now our default font.

Signed-off-by: Christopher Guindon <chris.guindon@eclipse-foundation.org>