### PR TITLE
add google analytics no script

### DIFF
--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -6,7 +6,7 @@ googleAnalytics = ""
 #disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [Params]
-  google_tag_manager = ""
+  google_tag_manager = "GTM-5WLCZXC"
   description = "Eclipse Foundation: Solstice theme for Hugo."
   subtitle = "Eclipse Foundation"
   seo_title_suffix = " | The Eclipse Foundation"

--- a/layouts/partials/google_tag_manager.html
+++ b/layouts/partials/google_tag_manager.html
@@ -4,7 +4,7 @@
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-5WLCZXC');</script>
+  })(window,document,'script','dataLayer','{{ . }}');</script>
   <!-- End Google Tag Manager -->
 {{- else }}
 {{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/google_tag_manager_no_script.html
+++ b/layouts/partials/google_tag_manager_no_script.html
@@ -1,0 +1,6 @@
+{{- with .Site.Params.google_tag_manager }}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{- end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,6 +10,7 @@
 
   SPDX-License-Identifier: EPL-2.0
 -->
+{{- partial "google_tag_manager_no_script.html" . }}
 <a class="sr-only" href="#content">{{ i18n "navigation-content-skip" }}</a>
 <header class="header-wrapper{{- with .Params.header_wrapper_class | default .Site.Params.header_wrapper_class }} {{ . }}{{end}}" id="header-wrapper">
   {{ partial "navbar.html" . }}


### PR DESCRIPTION
The noscript is required to validate the site with google search
console.

Signed-off-by: Christopher Guindon <chris.guindon@eclipse-foundation.org>