### PR TITLE
add params to custom footer class name and navbar logo

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,1 +1,0 @@
-[1028/083842.192:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[1028/083842.192:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,9 +13,7 @@
 <p id="back-to-top">
   <a class="visible-xs" href="#top">{{ i18n "navigation-back-to-top" }}</a>
 </p>
-{{- with .Params.footer_class | default .Site.Params.footer_class | default "solstice-footer"}} 
-<footer class="{{ . }}" id="{{ . }}">
-{{ end }}
+<footer id="{{- .Params.footer_id | default .Site.Params.footer_id | default "solstice-footer"}}" class="{{- .Params.footer_class | default .Site.Params.footer_class | default ""}}">
   <div class="container">
     <div class="row">
       <section class="col-sm-6 hidden-print" id="footer-eclipse-foundation">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,7 +13,9 @@
 <p id="back-to-top">
   <a class="visible-xs" href="#top">{{ i18n "navigation-back-to-top" }}</a>
 </p>
-<footer id="solstice-footer">
+{{- with .Params.footer_class | default .Site.Params.footer_class | default "solstice-footer"}} 
+<footer class="{{ . }}">
+{{ end }}
   <div class="container">
     <div class="row">
       <section class="col-sm-6 hidden-print" id="footer-eclipse-foundation">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
   <a class="visible-xs" href="#top">{{ i18n "navigation-back-to-top" }}</a>
 </p>
 {{- with .Params.footer_class | default .Site.Params.footer_class | default "solstice-footer"}} 
-<footer class="{{ . }}">
+<footer class="{{ . }}" id="{{ . }}">
 {{ end }}
   <div class="container">
     <div class="row">

--- a/layouts/partials/nav_toggle.html
+++ b/layouts/partials/nav_toggle.html
@@ -21,9 +21,9 @@
     </button>
   {{ end }}
   <div class="wrapper-logo-mobile">
-    {{- with .Site.Params.logo | default "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-foundation-white-orange.svg" }}
+    {{- with .Page.Params.logo | default .Site.Params.logo | default "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-foundation-white-orange.svg" }}
       <a class="navbar-brand visible-xs" title="{{ $.Site.Title }}" href="{{ "" | absLangURL }}">
-        <img width="{{ $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default-mobile img-responsive" src="{{ . | absURL }}" alt="{{ $.Site.Title }}" />
+        <img width="{{ $.Page.Params.logo_width | default $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default-mobile img-responsive" src="{{ . | absURL }}" alt="{{ $.Site.Title }}" />
       </a>
     {{ end }}
   </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -42,9 +42,9 @@
     <div class="row" id="header-row">
       <div class="{{ $.Site.Params.header_left_classes | default "col-sm-5 col-md-4" }}" id="header-left">
         <div class="wrapper-logo-default">
-          {{- with .Site.Params.logo | default "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-foundation-white-orange.svg" }}
-            <a title="{{ $.Site.Title}}" href="{{ "" | absLangURL }}">
-              <img width="{{ $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default img-responsive hidden-xs" src="{{ . | absURL }}" alt="{{ $.Site.Title}}" />
+          {{- with .Page.Params.logo | default .Site.Params.logo | default "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/images/logo/eclipse-foundation-white-orange.svg" }}
+            <a title="{{ $.Site.Title }}" href="{{ "" | absLangURL }}">
+              <img width="{{ $.Page.Params.logo_width | default $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default img-responsive hidden-xs" src="{{ . | absURL }}" alt="{{ $.Site.Title }}" />
             </a>
           {{ end }}
         </div>


### PR DESCRIPTION
To be able to add params to custom footer instead of {{ define footer }} for https://github.com/jakartaee/jakarta.ee/pull/929

And also add the ability to customize the page logo in navbar and mobile nav  instead of {{ define navbar }} 

It's a combine with https://github.com/EclipseFdn/solstice-assets/pull/184

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>