### PR TITLE
option to disable all breadcrumb

### DIFF
--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -23,6 +23,7 @@ googleAnalytics = ""
   show_events = true
   table_classes = "table table-bordered"
   hide_cfa_same_page = true
+  # hide_breadcrumb = true
 
 [Author]
   name = "Christopher Guindon"

--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -23,7 +23,6 @@ googleAnalytics = ""
   show_events = true
   table_classes = "table table-bordered"
   hide_cfa_same_page = true
-  # hide_breadcrumb = true
 
 [Author]
   name = "Christopher Guindon"

--- a/exampleSite/config/_default/menus.en.toml
+++ b/exampleSite/config/_default/menus.en.toml
@@ -42,6 +42,12 @@
     parent = "examples"
 
 [[main]]
+    name = "Without Breadcrumb"
+    url = "/without_breadcrumb/"
+    weight = 6
+    parent = "examples"
+
+[[main]]
     name = "Exemples de FAQ"
     url = "/faq/"
     weight = 4

--- a/exampleSite/content/without_breadcrumb/_index.md
+++ b/exampleSite/content/without_breadcrumb/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Test Without Breadcrumb"
+seo_title: "hugo-solstice-theme"
+description: "This is an example of the Eclipse Foundation Solstice theme for Hugo - page of Test Without Breadcrumb"
+date: 2018-04-05T15:50:25-04:00
+hide_sidebar: false
+hide_breadcrumb: true
+---
+
+This is an example of the Eclipse Foundation Solstice theme for Hugo - page of Test Without Breadcrumb
+
+You can use `hide_breadcrumb: true` in the page to disable it in one single page, or add it to the `config.toml` file to disbale it in all pages.

--- a/exampleSite/data/site_params.yml
+++ b/exampleSite/data/site_params.yml
@@ -134,3 +134,8 @@ items:
     description: URL to the YouTube page for the site. If there is no value set, will default to Eclispe Foundation page.
     values:
       - Absolute link to YouTube profile
+  - 
+    name: hide_breadcrumb
+    description: Hides the breadcrumb on all pages if set to true, otherwise ignored.
+    values:
+      - "true"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,7 +19,7 @@
 </head>
 <body>
   {{ block "header" . }}{{ partial "header.html" . }}{{ end }}
-  {{ block "breadcrumbs" . }}{{ if ne .Page.Params.hide_breadcrumb true }}{{ partial "breadcrumbs.html" . }}{{end}}{{ end }}
+  {{ block "breadcrumbs" . }}{{ if and (ne .Page.Params.hide_breadcrumb true) (ne .Site.Params.hide_breadcrumb true) }}{{ partial "breadcrumbs.html" . }}{{end}}{{ end }}
   {{ block "featured_story" . }}{{ partial "featured_story.html" . }}{{ end }}
   {{ block "main_prefix" . }}{{ partial "main_prefix.html" . }}{{ end }}
   {{ block "main" . }}{{ .Content }}{{ end }}


### PR DESCRIPTION
According to the requests from Philippe for https://github.com/EclipseFdn/opensourceinnovation.eu, I add this option in Confilg to disable breadcrumb for all pages.

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>