### PR TITLE
Use plural of table of contents for FAQ

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -269,7 +269,7 @@
   other = "Eclipse project downloads"
 
 [faq-list-heading]
-  other = "Table of content"
+  other = "Table of contents"
   
 [project-list-logo-alt]
   other = "{{ .name }} logo"


### PR DESCRIPTION
This is caught by https://github.com/EclipseFdn/ecdtools.eclipse.org/pull/73#issuecomment-734268756

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>