### PR TITLE
Remove agenda tab table spacing on mobile

### DIFF
--- a/exampleSite/content/components/agenda.md
+++ b/exampleSite/content/components/agenda.md
@@ -130,9 +130,11 @@ Targets ./data/en/2020/sample/agenda.yaml:
 
 ## Agenda w/ multiple streams
 
-Targets ./data/en/2020/sample/agenda.yaml:
+Targets ./data/en/multistream/agenda.yaml:
 
 
 {{< events/agenda event="multistream">}}
 
+
 {{< bootstrap/modal id="eclipsefdn-modal-event-session" >}}
+

--- a/exampleSite/data/en/multistream/agenda.yml
+++ b/exampleSite/data/en/multistream/agenda.yml
@@ -1,3 +1,4 @@
+complete: true
 types:
     - name: Demo
       id: demo 
@@ -13,16 +14,19 @@ sets:
         time: 15:00-18:00
         type: demo
         vod: "#1"
+        slides: "#slide-1"
       - name: How to 'how to'
         presenter: Jim Bob
         time: 18:00-19:00
         type: demo
         vod: "#2"
+        slides: "#slide-2"
       - name: Industry Keynote
         presenter: Eclipse Foundation, .etc
         time: 19:00-20:00
         type: keynote
         vod: "#3"
+        slides: "#slide-3"
   - name: Day 2
     items: 
        - name: The return of the Open-source software
@@ -30,16 +34,20 @@ sets:
          abstract: "<p>Sample abstract</p>"
          type: 1
          vod: "#1"
+         slides: "#slide-4"
        - name: How to 'how to' Awakens
          presenter: Jim Bob
          type: b2
          vod: "#2"
+         slides: "#slide-5"
        - name: A New Industry Keynote
          presenter: Eclipse Foundation, .etc
          type: b2
          vod: "#3"
+         slides: "#slide-6"
        - name: Revenge of the Best practices
          presenter: Adam A.
          type: 3
          vod: "#4"
+         slides: "#slide-7"
       

--- a/layouts/shortcodes/events/agenda.html
+++ b/layouts/shortcodes/events/agenda.html
@@ -90,7 +90,7 @@ span.eclipsefdn-agenda-legend-icon-{{ urlize .id }}::after {
       </ul>
     </div>
   </div>
-  <div class="content-nav-tab-body tab-content padding-40 margin-bottom-30" id="tabs-content">
+  <div class="content-nav-tab-body tab-content no-gutters-mobile padding-40 margin-bottom-30" id="tabs-content">
   {{ end }}
   {{ range $index, $set := $agendaItemsBase }}
     <!-- Check for slide and vod column -->


### PR DESCRIPTION
Part of https://github.com/EclipseFdn/hugo-solstice-theme/issues/188

For Hugo theme, the example agenda does not have long titles(And the current font-size is already small-14px), I'm thinking of adding font-size small when mobile view to events page separately (https://github.com/EclipseFdn/events.eclipse.org/pull/160).

I'm not adding the font size in `.eclipsefdn-agenda { table { } }` in solstice-assets is because it will be different due to different situations in the specific sites. On Hugo theme and Osdforum, 14px would be good, while for events, it needs to be 12px. 

wdyt?

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>