### PR TITLE
fix meta description use page contents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 node_js:
-  - "8"
-  - "9"
-  - "10"
-  - "11"
   - "12"
 install:
 - npm install

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
 <meta name="robots" content="noindex">
 <meta http-equiv="refresh" content="0; url={{ .Page.Params.redirect_url }}" />
 {{ end }}
-{{- with .Page.Params.description | default .Page.Params.summary  | default .Site.Params.description }}
+{{- with .Params.description | default .Params.Summary  | default .Site.Params.description }}
 <meta name="description" content="{{ . }}">
 <meta property="og:description" content="{{ . }}">
 <meta name="twitter:description" content="{{ . | truncate 200 }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
 <meta name="robots" content="noindex">
 <meta http-equiv="refresh" content="0; url={{ .Page.Params.redirect_url }}" />
 {{ end }}
-{{- with .Description | default .Summary  | default .Site.Params.description }}
+{{- with .Page.Params.description | default .Page.Params.summary  | default .Site.Params.description }}
 <meta name="description" content="{{ . }}">
 <meta property="og:description" content="{{ . }}">
 <meta name="twitter:description" content="{{ . | truncate 200 }}">


### PR DESCRIPTION
#197 

I think we need `.Params` to refer correctly the page params 

reference: 
https://gohugo.io/variables/page/

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>