### PR TITLE
Update Russian Language Switch

### DIFF
--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -17,5 +17,5 @@
   languageName = "简体中文"
   weight =  6
 [ru]
-  languageName = "русский язык"
+  languageName = "Русский"
   weight =  7


### PR DESCRIPTION
According to https://github.com/jakartaee/jakartaone.org/issues/250, we should use Русский for Russian language switcher. 

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>