### PR TITLE
Add custom jumbotron params

### DIFF
--- a/exampleSite/config/_default/menus.en.toml
+++ b/exampleSite/config/_default/menus.en.toml
@@ -54,6 +54,12 @@
     parent = "examples"
 
 [[main]]
+    name = "Custom Jumbotron"
+    url = "/custom-jumbotron/"
+    weight = 8
+    parent = "examples"
+
+[[main]]
     name = "Exemples de FAQ"
     url = "/faq/"
     weight = 4

--- a/exampleSite/content/custom-jumbotron/_index.md
+++ b/exampleSite/content/custom-jumbotron/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Custom Jumbotron"
-custom_jumbotron: "<h1>Custom Jumbotron 2021</h1><h2>An Custom Jumbotron Summit Event</h2><h2>Guiding the Future of IDE Development</h2><p>May 19, 2021 8AM-11AM PST (5PM-8PM CET)</p>"
+headline: "Custom Jumbotron 2021"
+subtitle: "An Custom Jumbotron Summit Event"
+custom_jumbotron: "<h2 class=\"margin-top-10\">Guiding the Future of IDE Development</h2><p class=\"margin-top-20\">May 19, 2021 8AM-11AM PST (5PM-8PM CET)</p>"
 date: 2021-03-07T08:00:00-24:00
 hide_breadcrumb: true
 summary: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet tortor id rhoncus pulvinar. Suspendisse nec aliquam ante. Sed vel convallis ex, ac elementum nisi."

--- a/exampleSite/content/custom-jumbotron/_index.md
+++ b/exampleSite/content/custom-jumbotron/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Custom Jumbotron"
+custom_jumbotron: "<h1>Custom Jumbotron 2021</h1><h2>An Custom Jumbotron Summit Event</h2><h2>Guiding the Future of IDE Development</h2><p>May 19, 2021 8AM-11AM PST (5PM-8PM CET)</p>"
+date: 2021-03-07T08:00:00-24:00
+hide_breadcrumb: true
+summary: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet tortor id rhoncus pulvinar. Suspendisse nec aliquam ante. Sed vel convallis ex, ac elementum nisi."
+links: [[href: "#",text: "Call for Papers"]]
+layout: single
+---
+
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet tortor id rhoncus pulvinar. Suspendisse nec aliquam ante. Sed vel convallis ex, ac elementum nisi. Nam eros lectus, tempus sit amet lorem at, laoreet blandit enim. Vestibulum metus justo, venenatis mollis ex quis, pretium ultricies orci. Pellentesque accumsan nulla ac leo convallis ornare. Cras rhoncus sapien lacus, vel tincidunt nibh lacinia ac. Vivamus vel egestas mi. Morbi nulla ante, rutrum quis congue non, luctus vehicula dui. Sed et nisi eu est egestas rhoncus.

--- a/exampleSite/data/doc_params.yml
+++ b/exampleSite/data/doc_params.yml
@@ -109,6 +109,11 @@ items:
       - "true"
   - 
     name: custom_jumbotron
-    description: Optional custom_jumbotron that will be inserted to replace the default Headlines, subtitles and taglines.
+    description: Optional custom_jumbotron that will be inserted after taglines, can include html tags. We recommend to not use taglines and custom_jumbotron at the same time.
+    values:
+      - Any string value
+  - 
+    name: custom_jumbotron_class
+    description: Optional custom_jumbotron_class that will be used for custom_jumbotron.
     values:
       - Any string value

--- a/exampleSite/data/doc_params.yml
+++ b/exampleSite/data/doc_params.yml
@@ -107,3 +107,8 @@ items:
     description: Show collapsible menu for mobile view on this page if set to true, otherwise is ignored. 
     values:
       - "true"
+  - 
+    name: custom_jumbotron
+    description: Optional custom_jumbotron that will be inserted to replace the default Headlines, subtitles and taglines.
+    values:
+      - Any string value

--- a/exampleSite/data/site_params.yml
+++ b/exampleSite/data/site_params.yml
@@ -144,3 +144,8 @@ items:
     description: Show collapsible menu for mobile view on all pages if set to true, otherwise is ignored. 
     values:
       - "true"
+  - 
+    name: custom_jumbotron_class
+    description: Optional custom_jumbotron_class that will be used for custom_jumbotron.
+    values:
+      - Any string value

--- a/layouts/partials/jumbotron.html
+++ b/layouts/partials/jumbotron.html
@@ -28,25 +28,14 @@
           </div>
         </div>
         {{end}} 
-        {{ if isset .Page.Params "links" }}
-        {{- with .Params.jumbotron_btn_class | default .Site.Params.jumbotron_btn_class | default "btn btn-primary"}}{{ $.Scratch.Set "jumbotron_btn" . }}{{end}}
-        <ul class="list-inline">
-          {{range $key,$val := index .Page.Params.links}}
-            <li><a class="{{ $.Scratch.Get "jumbotron_btn" }}" href="{{ (index $val 0).href}}">{{ (index $val 1).text}}</a></li>
-          {{end}} 
-        </ul>
-         {{end}} 
-      </div>
-    </div>
-  </div>
-</div>
 
-{{ else if isset .Page.Params "custom_jumbotron" }}
-<div class="jumbotron featured-jumbotron margin-bottom-0">
-  <div class="container">
-    <div class="row">
-      <div class="{{- .Params.jumbotron_class | default .Site.Params.jumbotron_class | default "col-md-20 col-md-offset-2 col-sm-18 col-sm-offset-3"}}">
-        {{ .Page.Params.custom_jumbotron | safeHTML }}
+         {{ if isset .Page.Params "custom_jumbotron" }}
+        <div class="row">
+          <div class="{{- .Params.custom_jumbotron_class | default .Site.Params.custom_jumbotron_class | default "col-sm-18 col-sm-offset-3"}}">
+            {{ .Page.Params.custom_jumbotron | safeHTML }}
+          </div>
+        </div>
+        {{end}} 
 
         {{ if isset .Page.Params "links" }}
         {{- with .Params.jumbotron_btn_class | default .Site.Params.jumbotron_btn_class | default "btn btn-primary"}}{{ $.Scratch.Set "jumbotron_btn" . }}{{end}}

--- a/layouts/partials/jumbotron.html
+++ b/layouts/partials/jumbotron.html
@@ -10,6 +10,7 @@
 
   SPDX-License-Identifier: EPL-2.0
 -->
+
 {{ if isset .Page.Params "headline" }}
 <div class="jumbotron featured-jumbotron margin-bottom-0">
   <div class="container">
@@ -27,6 +28,26 @@
           </div>
         </div>
         {{end}} 
+        {{ if isset .Page.Params "links" }}
+        {{- with .Params.jumbotron_btn_class | default .Site.Params.jumbotron_btn_class | default "btn btn-primary"}}{{ $.Scratch.Set "jumbotron_btn" . }}{{end}}
+        <ul class="list-inline">
+          {{range $key,$val := index .Page.Params.links}}
+            <li><a class="{{ $.Scratch.Get "jumbotron_btn" }}" href="{{ (index $val 0).href}}">{{ (index $val 1).text}}</a></li>
+          {{end}} 
+        </ul>
+         {{end}} 
+      </div>
+    </div>
+  </div>
+</div>
+
+{{ else if isset .Page.Params "custom_jumbotron" }}
+<div class="jumbotron featured-jumbotron margin-bottom-0">
+  <div class="container">
+    <div class="row">
+      <div class="{{- .Params.jumbotron_class | default .Site.Params.jumbotron_class | default "col-md-20 col-md-offset-2 col-sm-18 col-sm-offset-3"}}">
+        {{ .Page.Params.custom_jumbotron | safeHTML }}
+
         {{ if isset .Page.Params "links" }}
         {{- with .Params.jumbotron_btn_class | default .Site.Params.jumbotron_btn_class | default "btn btn-primary"}}{{ $.Scratch.Set "jumbotron_btn" . }}{{end}}
         <ul class="list-inline">


### PR DESCRIPTION
This is inspired by https://github.com/EclipseFdn/ecdtools.eclipse.org/issues/96#issuecomment-794110285

![image](https://user-images.githubusercontent.com/39588094/110514172-07ab7a80-80d5-11eb-9eb7-e70181cbf486.png)


An example will be https://deploy-preview-206--eclipsefdn-hugo-solstice-theme.netlify.app/custom-jumbotron/

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>