### PR TITLE
Use relative URLs for better preview when testing locally

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -75,14 +75,14 @@
 </footer>
 <!-- Placed at the end of the document so the pages load faster -->
 {{- with .Site.Params.js | default "https://www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/main.min.js"}}
-<script src="{{ . | absURL }}"></script>
+<script src="{{ . | relURL }}"></script>
 {{ end }}
 {{ if isset .Site.Params "hugo_js" }}
   {{- with .Site.Params.hugo_js }}
-    <script src="{{ . | absURL }}"></script>
+    <script src="{{ . | relURL }}"></script>
   {{ end }}
 {{ else }}
-    <script src="{{ "/js/solstice.hugo.js" | absURL }}"></script>
+    <script src="{{ "/js/solstice.hugo.js" | relURL }}"></script>
 {{ end }}
 
 <!-- Read in mustache templates registered in page scratch -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,12 +31,12 @@
 {{- end }}
 <meta name="author" content="{{ .Site.Author.name }}"/>
  {{- with  .Params.page_favicon | default .Site.Params.favicon | default "https://www.eclipse.org/favicon.ico"}}
-<link href='{{ . | absURL }}' rel='icon' type='image/x-icon'/>
+<link href='{{ . | relURL }}' rel='icon' type='image/x-icon'/>
 {{- end -}}
 <!-- Social Media Tags -->
 {{- with .Params.share_img | default .Params.image  | default .Site.Params.share_img | default .Site.Params.logo }}
-<meta property="og:image" content="{{ . | absURL }}" />
-<meta name="twitter:image" content="{{ . | absURL }}" />
+<meta property="og:image" content="{{ . | relURL }}" />
+<meta name="twitter:image" content="{{ . | relURL }}" />
 {{- end }}
 <meta name="twitter:card" content="summary" />
 {{- with .Site.Author.twitter }}
@@ -61,7 +61,7 @@
 {{ end }}
 {{ if ne .Page.Params.disable_css "true" }}
 {{- with .Site.Params.styles | default "https://eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/quicksilver.min.css" }}
-<link rel="stylesheet" href="{{ . | absURL }}">
+<link rel="stylesheet" href="{{ . | relURL }}">
 {{- end }}
 {{- end }}
 {{- partial "google_tag_manager.html" . }}

--- a/layouts/partials/nav_toggle.html
+++ b/layouts/partials/nav_toggle.html
@@ -36,7 +36,7 @@
         {{ end }}
 
       <a class="navbar-brand visible-xs" title="{{ $currentPageLogoTitle }}" href="{{ $currentPageLogoLink | absLangURL }}">
-        <img width="{{ $.Page.Params.logo_width | default $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default-mobile img-responsive" src="{{ $currentPageLogo | absURL }}" alt="{{ $currentPageLogoTitle }}" />
+        <img width="{{ $.Page.Params.logo_width | default $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default-mobile img-responsive" src="{{ $currentPageLogo | relURL }}" alt="{{ $currentPageLogoTitle }}" />
       </a>
     {{ end }}
   </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -59,7 +59,7 @@
             {{ end }}
         
             <a title="{{ $currentPageLogoTitle }}" href="{{ $currentPageLogoLink | absLangURL }}">
-              <img width="{{ $.Page.Params.logo_width | default $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default img-responsive hidden-xs" src="{{ $currentPageLogo | absURL }}" alt="{{ $currentPageLogoTitle }}" />
+              <img width="{{ $.Page.Params.logo_width | default $.Site.Params.logo_width | default "140"}}" class="logo-eclipse-default img-responsive hidden-xs" src="{{ $currentPageLogo | relURL }}" alt="{{ $currentPageLogoTitle }}" />
             </a>
             {{ end }}
 
@@ -76,7 +76,7 @@
           {{ $normalized_cta_url = printf "%s/" $normalized_cta_url }}
         {{ end }}
         
-        {{ $abs_cfa := printf "%s" ($normalized_cta_url | absURL) }}
+        {{ $abs_cfa := printf "%s" ($normalized_cta_url | relURL) }}
         {{ $is_cfa_page := 0 }}
         {{ if or (eq $normalized_cta_url .Permalink) (eq $abs_cfa .Permalink) }}
           {{ $is_cfa_page = 1 }}

--- a/layouts/shortcodes/eclipsefdn_adopters.html
+++ b/layouts/shortcodes/eclipsefdn_adopters.html
@@ -14,7 +14,7 @@
 {{ $ul_classes := .Get "ul_classes" | default "text-center list-inline" }}
 
 <div id="{{ $container_id }}" class="{{ $class }}"></div>
-<script src="{{ "js/eclipsefdn.adopters.js" | absURL}}"></script>
+<script src="{{ "js/eclipsefdn.adopters.js" | relURL}}"></script>
 <script>
   eclipseFdnAdopters.getWGList({src_root: "https://api.eclipse.org/adopters", working_group: "{{ $working_group }}", ul_classes: "{{ $ul_classes }}"})
 </script>


### PR DESCRIPTION
I found that testing locally is difficult when having an absolute URL for the stylesheet. 

Therefore I change this to a relative URL. The same of other occurrences in the file that should work with relative URLs as well. 
If someone puts an absolute URL there (for example the default URL), Hugo will still output the absolute URL if the host name is different from the hostname of the site. 

Please let me know there have been reasons to have this absolute. 

As this is only for testing locally, there is no need to hurry for a release.