### PR TITLE
improved handling for incubating projects

### DIFF
--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 	<ul class="nav nav-tabs" id="main-tabs" role="tablist">
 		<li role="presentation" class="active">
-			<a class="active"id="overview-tab" data-toggle="tab" href="#overview" role="tab" aria-controls="overview" aria-selected="true">Overview</a>
+			<a class="active" id="overview-tab" data-toggle="tab" href="#overview" role="tab" aria-controls="overview" aria-selected="true">Overview</a>
 		</li>
 	</ul>
 	<div class="tab-content">
@@ -11,6 +11,9 @@
 			</div>
 			<h2><strong>{{ i18n "project-single-licenses-label" }}</strong></h2>
 			<p>{{ .Params.license }}</p>
+			<div class="btn-group">
+				<a href="{{ .Params.website }}" class="btn btn-sm btn-warning details-link">{{ i18n "project-summary-website-label" }}</a>
+			</div>
 		</div>
 	</div>
 {{ end }}

--- a/layouts/projects/summary.html
+++ b/layouts/projects/summary.html
@@ -2,7 +2,11 @@
 	<div about="{{ .Permalink | relURL }}">
 		<div class="col-xs-6 col-md-4">
 			<a href="{{ .Permalink | relURL }}" >
+				{{ if .Params.is_incubated }}
+				<img class="img-responsive center-block margin-bottom-30" src="https://projects.eclipse.org/sites/all/modules/custom/pmi/project_state/images/incubating.png" />
+				{{ else }}
 				<img class="img-responsive center-block" src="{{ .Params.logo }}" alt="{{ i18n "project-summary-logo-text" . }}" />
+				{{ end }}
 			</a>
 		</div>
 
@@ -16,7 +20,7 @@
 				</ul>
 			{{ end }}
 			<div class="project-teaser-description">
-				{{ .Summary }} 
+				{{ .Summary }}
 				<p><a href="{{ .Permalink | relURL }}">{{ i18n "project-summary-read-more" }}</a></p>
 			</div>
 		</div>
@@ -27,6 +31,7 @@
 				{{ i18n "project-summary-latest-release" }} <a href="{{ .Params.download_url }}"><span class="badge version">{{ .Params.latest_version }}</span></a>
 			</p>
 			{{ end }}
+			{{ if ne .Params.download_url nil }}
 			<div class="btn-group">
 				<a href="{{ .Params.download_url }}" class="btn btn-sm btn-warning details-link">{{ i18n "project-summary-download-label" }}</a>
 				<button type="button" class="btn btn-sm btn-warning dropdown-toggle details-link" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -36,6 +41,11 @@
 					<li><a href="{{ .Params.website }}">{{ i18n "project-summary-website-label" }}</a></li>
 				</ul>
 			</div>
+			{{ else }}
+			<div class="btn-group">
+				<a href="{{ .Params.website }}" class="btn btn-sm btn-warning details-link">{{ i18n "project-summary-website-label" }}</a>
+			</div>
+			{{ end }}
 		</div>
 		<!-- End release col -->
 	</div>


### PR DESCRIPTION
We used the project list on the AsciiDoc WG page and changed the following items that might be interesting for other projects as well. Therefore I create this pull request. If something shouldn't be added to the theme, please let me know and I'll remove it from the PR.

Live view (include also some other minor changes like removing the tags in the single project view): 
https://eclipsefdn-asciidoc-wg.netlify.app/projects/ 

Single Project View:
* add link to project as "call to action"

Project Summary View:
* start with a dotted line as the list also ends with a dotted line
* show incubating logo for incubating projects like on the single project view
* show link to website when there is no download link

There is no need to rush here, we've duplicated the templates in the WG for now. 